### PR TITLE
Update exec console output to use safe colour output for all cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .bob
 .DS_Store
 node_modules

--- a/lib/bagofcli.js
+++ b/lib/bagofcli.js
@@ -249,7 +249,7 @@ function exitCb(errorCb, successCb) {
 
   if (!errorCb) {
     errorCb = function (err) {
-      console.error(color.red(err.message || JSON.stringify(err)));
+      console.error(colors.red(err.message || JSON.stringify(err)));
     };
   }
 

--- a/lib/bagofcli.js
+++ b/lib/bagofcli.js
@@ -208,12 +208,14 @@ function exec(command, fallthrough, cb) {
     cb(err, result);
   });
 
+  var colors = require('colors/safe');
+
   _exec.stdout.on('data', function (data) {
-    process.stdout.write(data.green);
+    process.stdout.write(colors.green(data.toString()));
   });
 
   _exec.stderr.on('data', function (data) {
-    process.stderr.write(data.red);
+    process.stderr.write(colors.red(data.toString()));
   });
 }
 

--- a/lib/bagofcli.js
+++ b/lib/bagofcli.js
@@ -249,13 +249,13 @@ function exitCb(errorCb, successCb) {
 
   if (!errorCb) {
     errorCb = function (err) {
-      console.error((err.message || JSON.stringify(err)).red);
+      console.error(color.red(err.message || JSON.stringify(err)));
     };
   }
 
   if (!successCb) {
     successCb = function (result) {
-      console.log(result.green);
+      console.log(colors.green(result.toString()));
     };
   }
 
@@ -447,11 +447,11 @@ function spawn(command, args, cb) {
   var _spawn = child.spawn(command, args);
 
   _spawn.stdout.on('data', function (data) {
-    process.stdout.write(data.green);
+    process.stdout.write(colors.green(data.toString()));
   });
 
   _spawn.stderr.on('data', function (data) {
-    process.stderr.write(data.red);
+    process.stderr.write(colors.red(data.toString()));
   });
 
   _spawn.on('exit', function (code) {


### PR DESCRIPTION
When child process outputs content use colours/safe library to change colour of output to the parent console output.